### PR TITLE
Update hello_spec.rb

### DIFF
--- a/learn_ruby/hello/hello_spec.rb
+++ b/learn_ruby/hello/hello_spec.rb
@@ -117,16 +117,16 @@ require "hello"
 
 describe "the hello function" do
   it "says hello" do
-    hello.should == "Hello!"
+    expect(hello) == "Hello!"
   end
 end
 
 describe "the greet function" do
   it "says hello to someone" do
-    greet("Alice").should == "Hello, Alice!"
+    expect(greet("Alice")) == "Hello, Alice!"
   end
 
   it "says hello to someone else" do
-    greet("Bob").should == "Hello, Bob!"
+    expect(greet("Bob")) == "Hello, Bob!"
   end
 end


### PR DESCRIPTION
To implement the new expect feature in rpsec and remove the overly verbose deprecation warnings that make it hard to read the actual errors. PS I am new to this but worked for me based off http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/